### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Add HashRing as a dependency in your `mix.exs` file
 ```elixir
 defp deps do
   [
-    {hash_ring: "~> 1.0"}
+    {hash_ring_ex: "~> 1.0"}
   ]
 end
 ```


### PR DESCRIPTION
The package name in the installation section was wrong, changed it to 'hash_ring_ex'
