### PR TITLE
Use where_is_file if priv_dir does not exist

### DIFF
--- a/lib/hash_ring/driver.ex
+++ b/lib/hash_ring/driver.ex
@@ -170,7 +170,7 @@ defmodule HashRing.Driver do
   defp lib_path do
     case :code.priv_dir(:hash_ring_ex) do
       {:error, :bad_name} ->
-        Path.join([Path.dirname(:code.which(:hash_ring_ex)), "..", "priv"])
+        :code.where_is_file('#{@driver}.so') |> Path.dirname
       path ->
         path
     end


### PR DESCRIPTION
This allows hash_ring to be used as a dependancy to an escript. `priv_dir` and `which` don't
work when compiling with escript, as all files are in one directory `my_escript_app/`.
