### PR TITLE
Rebuild structure so that priv is correctly linked

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -44,4 +44,6 @@ defmodule Mix.Tasks.Compile.Rebar do
     Mix.shell.cmd "./rebar g-d"
     Mix.shell.cmd "./rebar co"
   end
+
+  Mix.Project.build_structure()
 end


### PR DESCRIPTION
The problem is referred here:

https://groups.google.com/forum/#!topic/elixir-lang-talk/9TmuUv3y9_g

Basically, when the binary application is used as a dependency, the `priv` directory is not linked. Mix links `priv` directories before actual compilation is done. On subsequent compilations, it works, because then the `priv` directory is generated already from the previous run. 